### PR TITLE
Bugfix: #13 - Avoid duplicate values for subject and html fields

### DIFF
--- a/Sources/SWMailgun/Network/MailgunAPI.swift
+++ b/Sources/SWMailgun/Network/MailgunAPI.swift
@@ -47,7 +47,10 @@ extension MailgunAPI: NKFlowTarget {
     switch self {
     case .sendEmail(_, let email, _):
       let parameters = email.toJSON
-      return .requestCompositeParameters(bodyParameters: [:], urlParameters: parameters)
+      if email.template?.isEmpty ?? true {
+        return .requestCompositeParameters(bodyParameters: [:], urlParameters: parameters)
+      }
+      return .requestParameters(parameters, encoding: .formData)
     }
   }
 

--- a/Sources/SWMailgun/Network/MailgunAPI.swift
+++ b/Sources/SWMailgun/Network/MailgunAPI.swift
@@ -47,7 +47,7 @@ extension MailgunAPI: NKFlowTarget {
     switch self {
     case .sendEmail(_, let email, _):
       let parameters = email.toJSON
-      return .requestParameters(parameters, encoding: .formData)
+      return .requestCompositeParameters(bodyParameters: [:], urlParameters: parameters)
     }
   }
 


### PR DESCRIPTION
Fix for #13.

@thejohnlima 
The reason this is happening is because we're using `POST` with `.formData` parameter encoding, but also including the parameters as `.requestParameters`:

```
(lldb) po try request.encoded(parameters: parameters, paramEncode: encode)
▿ https://api:<MY_KEY>@api.mailgun.net/v3/<MY_DOMAIN>/messages?to=<MY_EMAIL>&html=%3Cb%3ETest%3C/b%3E&subject=This%20is%20a%20test&from=Excited%20User%20%3Chello.world@mail.com%3E
  ▿ url : Optional<URL>
    ▿ some : https://api:<MY_KEY>@api.mailgun.net/v3/ladderapp.ca/messages?to=<MY_EMAIL>&html=%3Cb%3ETest%3C/b%3E&subject=This%20is%20a%20test&from=Excited%20User%20%3Chello.world@mail.com%3E
      - _url : https://api:<MY_KEY>@api.mailgun.net/v3/ladderapp.ca/messages?to=<MY_EMAIL>&html=%3Cb%3ETest%3C/b%3E&subject=This%20is%20a%20test&from=Excited%20User%20%3Chello.world@mail.com%3E
  - cachePolicy : 0
  - timeoutInterval : 60.0
  - mainDocumentURL : nil
  - networkServiceType : __C.NSURLRequestNetworkServiceType
  - allowsCellularAccess : true
  ▿ httpMethod : Optional<String>
    - some : "POST"
```

Which causes them to be included in the message twice.

If updated to `return .requestCompositeParameters(bodyParameters: [:], urlParameters: parameters)` we do not get duplicated values:

**Before**
<img width="469" alt="Screenshot 2023-02-12 at 2 38 50 PM" src="https://user-images.githubusercontent.com/1120510/218337014-041098e7-de84-4bc9-bf46-dde6c471172e.png">

<img width="283" alt="Screenshot 2023-02-12 at 2 39 00 PM" src="https://user-images.githubusercontent.com/1120510/218337015-c79e545f-d27a-430a-81ea-03bd32651e2e.png">

**After**
<img width="346" alt="Screenshot 2023-02-12 at 3 49 24 PM" src="https://user-images.githubusercontent.com/1120510/218337017-615f0c57-2760-40d6-b4d8-5a000d11ae7d.png">

<img width="264" alt="Screenshot 2023-02-12 at 3 49 29 PM" src="https://user-images.githubusercontent.com/1120510/218337018-ded54cb9-b87f-4c6f-be45-6bfb7ed2ae1e.png">